### PR TITLE
Lambda smart deploy with webpack changes

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -7,6 +7,7 @@ const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const generateZip = require('./generateZip');
 const ServerlessError = require('../../../serverless-error');
+const getHashForFilePath = require('../getHashForFilePath');
 
 const prepareCustomResourcePackage = _.memoize(async (zipFilePath) =>
   BbPromise.all([generateZip(), fse.mkdirs(path.dirname(zipFilePath))])
@@ -74,16 +75,16 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
   // TODO: check every once in a while if external packages are still necessary
   serverless.cli.log('Installing dependencies for custom CloudFormation resources...');
 
-  const zipFileBasename = await prepareCustomResourcePackage(zipFilePath);
+  await prepareCustomResourcePackage(zipFilePath);
   let S3Bucket = {
     Ref: awsProvider.naming.getDeploymentBucketLogicalId(),
   };
   if (serverless.service.package.deploymentBucket) {
     S3Bucket = serverless.service.package.deploymentBucket;
   }
-  const s3Folder = serverless.service.package.artifactDirectoryName;
-  const s3FileName = zipFileBasename;
-  const S3Key = `${s3Folder}/${s3FileName}`;
+  const hash = await getHashForFilePath(zipFilePath, 'hex');
+  const { name: fileName } = path.parse(zipFilePath);
+  const S3Key = `${serverless.service.package.artifactDirectoryName}/${fileName}/${hash}`;
 
   const customDeploymentRole = awsProvider.getCustomDeploymentRole();
 

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -9,6 +9,7 @@ const filesize = require('filesize');
 const normalizeFiles = require('../../lib/normalizeFiles');
 const getLambdaLayerArtifactPath = require('../../utils/getLambdaLayerArtifactPath');
 const ServerlessError = require('../../../../serverless-error');
+const getHashForFilePath = require('../../getHashForFilePath');
 
 const MAX_CONCURRENT_ARTIFACTS_UPLOADS =
   Number(process.env.SLS_MAX_CONCURRENT_ARTIFACTS_UPLOADS) || 3;
@@ -51,12 +52,49 @@ module.exports = {
     return this.provider.request('S3', 'upload', params);
   },
 
+  async isAlreadyUploaded(key) {
+    try {
+      const params = {
+        Bucket: this.bucketName,
+        Key: key,
+      };
+      await this.provider.request('S3', 'headObject', params);
+      return true;
+    } catch (error) {
+      if (error.code !== 'AWS_S3_HEAD_OBJECT_NOT_FOUND') {
+        this.serverless.cli.log(`Warning! ${error.code} on headObject for ${key}...`);
+      }
+      return false;
+    }
+  },
+
   async uploadZipFile(artifactFilePath) {
-    const fileName = artifactFilePath.split(path.sep).pop();
+    const { name: fileName } = path.parse(artifactFilePath);
+
+    const stats = (() => {
+      try {
+        return fs.statSync(artifactFilePath);
+      } catch (error) {
+        throw new ServerlessError(
+          `Cannot read file artifact "${artifactFilePath}": ${error.message}`,
+          'INACCESSIBLE_FILE_ARTIFACT'
+        );
+      }
+    })();
 
     // TODO refactor to be async (use util function to compute checksum async)
     const data = fs.readFileSync(artifactFilePath);
     const fileHash = crypto.createHash('sha256').update(data).digest('base64');
+    const hash = await getHashForFilePath(artifactFilePath, 'hex');
+
+    const s3Key = `${this.serverless.service.package.artifactDirectoryName}/${fileName}/${hash}`;
+
+    if (await this.isAlreadyUploaded(s3Key)) {
+      this.serverless.cli.log(`Artifact ${s3Key} already uploaded`);
+      return;
+    }
+
+    this.serverless.cli.log(`Uploading artifact ${fileName} to S3 (${filesize(stats.size)})...`);
 
     const artifactStream = fs.createReadStream(artifactFilePath);
     // As AWS SDK request might be postponed (requests are queued)
@@ -67,7 +105,7 @@ module.exports = {
 
     let params = {
       Bucket: this.bucketName,
-      Key: `${this.serverless.service.package.artifactDirectoryName}/${fileName}`,
+      Key: s3Key,
       Body: artifactStream,
       ContentType: 'application/zip',
       Metadata: {
@@ -80,12 +118,11 @@ module.exports = {
       params = setServersideEncryptionOptions(params, deploymentBucketObject);
     }
 
-    const response = await this.provider.request('S3', 'upload', params);
+    await this.provider.request('S3', 'upload', params);
     // Interestingly, if request handling was queued, and stream errored (before being consumed by
     // AWS SDK) then SDK call succeeds without actually uploading a file to S3 bucket.
     // Below line ensures that eventual stream error is communicated
     if (streamError) throw streamError;
-    return response;
   },
 
   async uploadFunctionsAndLayers() {
@@ -142,24 +179,7 @@ module.exports = {
 
     return BbPromise.map(
       artifactFilePaths,
-      (artifactFilePath) => {
-        const stats = (() => {
-          try {
-            return fs.statSync(artifactFilePath);
-          } catch (error) {
-            throw new ServerlessError(
-              `Cannot read file artifact "${artifactFilePath}": ${error.message}`,
-              'INACCESSIBLE_FILE_ARTIFACT'
-            );
-          }
-        })();
-
-        const fileName = path.basename(artifactFilePath);
-        this.serverless.cli.log(
-          `Uploading service ${fileName} file to S3 (${filesize(stats.size)})...`
-        );
-        return this.uploadZipFile(artifactFilePath);
-      },
+      (artifactFilePath) => this.uploadZipFile(artifactFilePath),
       { concurrency: MAX_CONCURRENT_ARTIFACTS_UPLOADS }
     );
   },

--- a/lib/plugins/aws/getHashForFilePath.js
+++ b/lib/plugins/aws/getHashForFilePath.js
@@ -4,7 +4,7 @@ const memoize = require('memoizee');
 const crypto = require('crypto');
 const fs = require('fs');
 
-const getHashForFilePath = memoize(
+const getHashForFilePathWithBase64 = memoize(
   async (filePath) => {
     const fileHash = crypto.createHash('sha256');
     fileHash.setEncoding('base64');
@@ -29,5 +29,13 @@ const getHashForFilePath = memoize(
   },
   { promise: true }
 );
+
+/* This approach will keep the benefit of hashing memoization
+   per each file just once, no matter what encoding is needed. */
+const getHashForFilePath = async (filePath, encoding = 'base64') => {
+  const fileHash = await getHashForFilePathWithBase64(filePath);
+  if (encoding === 'base64') return fileHash;
+  return Buffer.from(fileHash, 'base64').toString(encoding);
+};
 
 module.exports = getHashForFilePath;

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -8,7 +8,7 @@ const _ = require('lodash');
 const path = require('path');
 const ServerlessError = require('../../../../serverless-error');
 const deepSortObjectByKey = require('../../../../utils/deepSortObjectByKey');
-const getHashForFilePath = require('../lib/getHashForFilePath');
+const getHashForFilePath = require('../../getHashForFilePath');
 const parseS3URI = require('../../utils/parse-s3-uri');
 
 class AwsCompileFunctions {
@@ -232,9 +232,8 @@ class AwsCompileFunctions {
         ? this.serverless.service.package.deploymentBucket
         : { Ref: 'ServerlessDeploymentBucket' };
 
-      functionResource.Properties.Code.S3Key = `${
-        this.serverless.service.package.artifactDirectoryName
-      }/${artifactFilePath.split(path.sep).pop()}`;
+      const hash = await getHashForFilePath(artifactFilePath, 'hex');
+      functionResource.Properties.Code.S3Key = `${this.serverless.service.package.artifactDirectoryName}/${functionName}/${hash}`;
       functionResource.Properties.Runtime = functionObject.runtime;
     } else {
       functionResource.Properties.Code.ImageUri = functionImageUri;

--- a/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
+++ b/lib/plugins/aws/package/lib/generateArtifactDirectoryName.js
@@ -4,11 +4,9 @@ module.exports = {
   generateArtifactDirectoryName() {
     // Don't regenerate name if it's already set
     if (!this.serverless.service.package.artifactDirectoryName) {
-      const date = new Date();
       const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
-      const dateString = `${date.getTime().toString()}-${date.toISOString()}`;
       const prefix = this.provider.getDeploymentPrefix();
-      this.serverless.service.package.artifactDirectoryName = `${prefix}/${serviceStage}/${dateString}`;
+      this.serverless.service.package.artifactDirectoryName = `${prefix}/${serviceStage}`;
     }
   },
 };

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -42,7 +42,7 @@ class AwsRollback {
     const serviceName = this.serverless.service.service;
     const stage = this.provider.getStage();
     const deploymentPrefix = this.provider.getDeploymentPrefix();
-    const prefix = `${deploymentPrefix}/${serviceName}/${stage}`;
+    const prefix = `${deploymentPrefix}/${stage}`;
 
     return this.provider
       .request('S3', 'listObjectsV2', {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -12,7 +12,7 @@ const AwsCompileFunctions = require('../../../../../../../lib/plugins/aws/packag
 const Serverless = require('../../../../../../../lib/Serverless');
 const runServerless = require('../../../../../../utils/run-serverless');
 const fixtures = require('../../../../../../fixtures/programmatic');
-const getHashForFilePath = require('../../../../../../../lib/plugins/aws/package/lib/getHashForFilePath');
+const getHashForFilePath = require('../../../../../../../lib/plugins/aws/getHashForFilePath');
 
 const { getTmpDirPath, createTmpFile } = require('../../../../../../utils/fs');
 

--- a/test/unit/lib/plugins/aws/package/lib/getHashForFilePath.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/getHashForFilePath.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const getHashForFilePath = require('../../../../../../../lib/plugins/aws/package/lib/getHashForFilePath');
+const getHashForFilePath = require('../../../../../../../lib/plugins/aws/getHashForFilePath');
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
**What it does?**

- Adjust format of artifact paths to `<prefix>/<stage>/<function_name>/<hash>`

**What else is important?**

- It assumes that ZIP files created in the package step have deterministic hash - they don't change per each build, just when the actual content change. This is true assumption for pure serverless config and will be true for serverless-webpack config assuming [this ticket](https://github.com/serverless-heaven/serverless-webpack/issues/881) will be resolved, which should be the case with [this PR](https://github.com/serverless-heaven/serverless-webpack/pull/911#pullrequestreview-717912281) after suggested changes are applied 
- This is just PoC, not to be merged yet. It will require lots of things to happen:
  - Rollback handling
  - Review of configuration that can affect the behavior
  - Tests updates
  - ... :question: 